### PR TITLE
Entferne autocomplete von checkboxes

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -42,6 +42,9 @@ class RegistrationsController < ApplicationController
 		@registration.assign_attributes(permitted_attributes(@registration))
 		@registration.set_defaults
 		if @registration.save
+			# Verschicke Emails an die angemeldete Person
+			mailer = RegistrationMailer.with(registration: @registration)
+			mailer.new_registration_for_participant_by_organizer_email.deliver_now
 			redirect_to @registration, notice: t('.success')
 		else
 			render :new

--- a/app/helpers/event_table_helper.rb
+++ b/app/helpers/event_table_helper.rb
@@ -1,0 +1,11 @@
+module EventTableHelper
+
+  def checkbox(id, text, checked)
+    content_tag :label do
+      content_tag :input, {:autocomplete => 'off', :type => 'checkbox', :id => id, :checked => checked} do
+        concat text
+      end
+    end
+  end
+end
+

--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -12,6 +12,11 @@ class RegistrationMailer < ApplicationMailer
 			"Anmeldung zur Veranstaltung %s erfolgeich", @event.title))
 	end
 
+	def new_registration_for_participant_by_organizer_email
+		mail(:to => @person.email_address, :subject => sprintf(
+			"Anmeldung zur Veranstaltung %s",  @person.full_name, @event.title))
+	end
+
 
 	def edit_registration_for_participant_email
 		mail(:to => @person.email_address,	:subject => sprintf(

--- a/app/views/events/registrations.erb
+++ b/app/views/events/registrations.erb
@@ -8,14 +8,14 @@
 <div class="flexlayout">
 <fieldset>
 	<legend>Spalten auswählen</legend>
-	<label><input type="checkbox" id="show_person_field" checked> Geschlecht und Geburtstag anzeigen</label>
-	<label><input type="checkbox" id="show_phone_field" checked> Handynummer anzeigen</label>
-	<label><input type="checkbox" id="show_travel_field" checked> Anreiseinformationen anzeigen</label>
-	<label><input type="checkbox" id="show_address_field"> Addressdaten anzeigen</label>
-	<label><input type="checkbox" id="show_status_field"> Anmeldestatus anzeigen</label>
+	<%= checkbox("show_person_field", "Geschlecht und Geburtstag anzeigen", true) %>
+	<%= checkbox("show_phone_field", "Handynummer anzeigen", true) %>
+	<%= checkbox("show_travel_field", "Anreiseinformationen anzeigen", true) %>
+	<%= checkbox("show_address_field", "Addressdaten anzeigen", false) %>
+	<%= checkbox("show_status_field", "Anmeldestatus anzeigen", false) %>
 	<% if view_private %>
-	<label><input type="checkbox" id="show_payment_field"> Zahlungsinformationen anzeigen</label>
-	<label><input type="checkbox" id="show_other_field"> Sonstige Daten anzeigen</label>
+	<%= checkbox("show_payment_field", "Zahlungsinformationen anzeigen", false) %>
+	<%= checkbox("show_other_field", "Sonstige Daten anzeigen", false) %>
 	<% end %>
 	<div class="actions">
 		<%= download_table_button('#registrations_table') %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
 	<%= javascript_include_tag 'application' %>
 	<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 	<meta name="viewport" content="width=device-width; initial-scale=1.0">
+	<link rel="shortcut icon" href="https://qed-verein.de/favicon.ico">
 </head>
 
 <body>

--- a/app/views/people/as_table.html.erb
+++ b/app/views/people/as_table.html.erb
@@ -11,19 +11,19 @@
 	<div class="flexlayout">
 	<fieldset>
 		<label>Personen auswählen</label>
-		<label><input type="checkbox" id="show_member_row" checked> Mitglieder anzeigen</label>
-		<label><input type="checkbox" id="show_non_member_row" checked> Nichtmitglieder anzeigen</label>
+		<%= checkbox("show_member_row", "Mitglieder anzeigen", true) %>
+		<%= checkbox("show_non_member_row", "Nichtmitglieder anzeigen", true) %>
 	</fieldset>
 	<fieldset>
 		<label>Informationen auswählen</label>
-		<label><input type="checkbox" id="show_person_field" checked> Geschlecht und Geburtstag</label>
-		<label><input type="checkbox" id="show_phone_field" checked> Handynummer</label>
-		<label><input type="checkbox" id="show_email_field" checked> Emailadresse</label>
-		<label><input type="checkbox" id="show_address_field" checked> Addressdaten</label>
-		<label><input type="checkbox" id="show_account_field"> Benutzerkonto</label>
-		<label><input type="checkbox" id="show_status_field"> Mitgliedsstatus</label>
+		<%= checkbox("show_person_field", "Geschlecht und Geburtstag", true) %>
+		<%= checkbox("show_phone_field", "Handynummer", true) %>
+		<%= checkbox("show_email_field", "Emailadresse", true) %>
+		<%= checkbox("show_address_field", "Addressdaten", true) %>
+		<%= checkbox("show_account_field", "Benutzerkonto", false) %>
+		<%= checkbox("show_status_field", "Mitgliedsstatus", false) %>
 		<% if @person_policy.view_payments? %>
-		<label><input type="checkbox" id="show_payment_field"> Zahlungsstatus</label>
+		  <%= checkbox("show_payment_field", "Zahlungsstatus", false) %>
 		<% end %>
 	</fieldset>
 	</div>

--- a/app/views/registration_mailer/new_registration_for_participant_by_organizer_email.erb
+++ b/app/views/registration_mailer/new_registration_for_participant_by_organizer_email.erb
@@ -1,0 +1,13 @@
+<p>Hallo <%= @registration.person.full_name %>!</p>
+
+<p>Du wurdest für die Veranstaltung
+<b><%= link_to(@registration.event.title, @registration.event) %></b> angemeldet. Falls du das nicht wolltest, melde dich bei uns.</p>
+
+<p>Unter folgendem Link kannst du deine Anmeldedaten einsehen und bis zum Anmeldeschluss noch abändern:
+ <b><%= link_to("Anmeldedaten anzeigen", @registration) %></b></p>
+
+<p>Beachte bitte, dass deine Anmeldung erst gültig ist, nachdem dein Teilnahmebeitrag auf unserem Konto angekommen ist.
+Die Kontoinformationen findest du unter folgendem Link:
+ <b><%= link_to "Kontodaten anzeigen", Rails.configuration.banking_link %></b></p>
+
+<p>Ansonsten freuen wir uns schon herzlich auf deine Teilnahme!</p>


### PR DESCRIPTION
Autocomplete sorgt für caching, was bei checkboxes, die über javascript die Anzeige von Spalten regeln, doof ist.