### PR TITLE
Verstecke inaktive TN in der Tabellenübersicht einer Veranstaltung

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -70,6 +70,14 @@ class Registration < ApplicationRecord
 		end
 	end
 
+	def self.status_active?(status)
+		['pending', 'confirmed'].include?(status)
+	end
+
+	def active?
+		Registration.status_active?(status)
+	end
+
 	private
 
 	# Prüft ob die zeitliche Reihenfolge von Anreise und Abreise korrekt ist.
@@ -81,14 +89,12 @@ class Registration < ApplicationRecord
 
 	# Prüft ob noch Plätze für Anmeldung verfügbar sind.
 	def max_participants_not_exceeded
-		r = ['pending', 'confirmed'] # TODO Sollen offene Anmeldungen ebenfalls zählen
-
 		# Zähle wie viele Plätze vorher benötigt wurden
 		count = event.participants.count
 		# Bei einer Zusage brauchen wir einen Platz mehr
-		count += 1 if r.include?(status) && !r.include?(status_was)
+		count += 1 if active? && !Registration.status_active?(status_was)
 		# Bei einer Absage brauchen wir einen Platz weniger
-		count -= 1 if !r.include?(status) && r.include?(status_was)
+		count -= 1 if !active? && Registration.status_active?(status_was)
 
 		unless count <= event.max_participants
 			errors.add :base, "Die Anzahl der angemeldeten Teilnehmer darf das Teilnehmerlimit nicht übersteigen"

--- a/app/views/events/registrations.erb
+++ b/app/views/events/registrations.erb
@@ -13,6 +13,7 @@
 	<%= checkbox("show_travel_field", "Anreiseinformationen anzeigen", true) %>
 	<%= checkbox("show_address_field", "Addressdaten anzeigen", false) %>
 	<%= checkbox("show_status_field", "Anmeldestatus anzeigen", false) %>
+	<%= checkbox("show_inactive", "Inaktive Teilnehmende anzeigen", false) %>
 	<% if view_private %>
 	<%= checkbox("show_payment_field", "Zahlungsinformationen anzeigen", false) %>
 	<%= checkbox("show_other_field", "Sonstige Daten anzeigen", false) %>
@@ -56,7 +57,7 @@
 </thead>
 <tbody>
 	<% @event.registrations.each do |r| %>
-	<tr>
+	<tr class='<%= 'inactive' if !r.active? %>'>
 		<td></td>
 		<td><%= link_to r.person.first_name, r %></td>
 		<td><%= link_to r.person.last_name, r %></td>


### PR DESCRIPTION
Diese sind meistens uninteressant und stören bei schnellen Überblicken.