### PR TITLE
Fix problems with hidden rows effecting coloring.

### DIFF
--- a/app/assets/javascripts/table_download_helper.js
+++ b/app/assets/javascripts/table_download_helper.js
@@ -11,4 +11,18 @@ function updateVisibility(item) {
 	if(checked)
 		$(selector).show();
 	else
-		$(selector).hide();}
+		$(selector).hide();
+}
+
+function hideRow(item, row_selector, checked_is_hidden) {
+	hide = $(item).is(':checked') == checked_is_hidden;
+	rows = $(row_selector);
+	let is_hidden = rows.parent().is('div');
+	if (is_hidden !== hide) {
+		if (hide) {
+			rows.wrap('<div style="display: none"> </div>')
+		} else {
+			rows.unwrap('div')
+		}
+	}
+}

--- a/app/views/events/registrations.erb
+++ b/app/views/events/registrations.erb
@@ -13,7 +13,7 @@
 	<%= checkbox("show_travel_field", "Anreiseinformationen anzeigen", true) %>
 	<%= checkbox("show_address_field", "Addressdaten anzeigen", false) %>
 	<%= checkbox("show_status_field", "Anmeldestatus anzeigen", false) %>
-	<%= checkbox("show_inactive", "Inaktive Teilnehmende anzeigen", false) %>
+	<%= checkbox("unhide_inactive", "Inaktive Teilnehmende anzeigen", false) %>
 	<% if view_private %>
 	<%= checkbox("show_payment_field", "Zahlungsinformationen anzeigen", false) %>
 	<%= checkbox("show_other_field", "Sonstige Daten anzeigen", false) %>
@@ -112,6 +112,10 @@
 <script>
 $(function(){
 	$("#registrations_table").stupidtable();
-	$('#event_participants_data input[type=checkbox]').each(function(index, item) {updateVisibility(item)})})
+	$('#event_participants_data input[type=checkbox]').each(function(index, item) {updateVisibility(item)});
+    hideRow($('#unhide_inactive'), '.inactive', false);
+  })
+
 $('#event_participants_data input[type=checkbox]').click(function() {updateVisibility(this)});
+$('#unhide_inactive').click(function() { hideRow(this, '.inactive', false); });
 </script>


### PR DESCRIPTION
Mein PR #2 der inaktive Teilnehmer versteckt, hat leider die Zeilenfärbung kaputt gemacht. `:nth-of-type` zählt natürlich auch `display: none` mit. Der einzige Weg darum ist die versteckten Zeilen aus dem DOM zu entfernen oder in einen anderen tag zu wrappen. Ich tue hier zweiteres und wrappe sie in ein `div`, das auch gleich das `display: none` übernimmt.